### PR TITLE
docs: typo(client-size -> client-side)

### DIFF
--- a/docs/guide/learn-more.md
+++ b/docs/guide/learn-more.md
@@ -88,7 +88,7 @@ Here is what the cache can look like:
 
 rstore is designed with a local-first approach, meaning that it prioritizes local data access and computation. This design choice allows for faster data retrieval and manipulation, as well as improved performance in scenarios where network connectivity may be unreliable or slow.
 
-In practice this means that all data reads in components are computed client-size from the cache, including filtering and sorting.
+In practice this means that all data reads in components are computed client-side from the cache, including filtering and sorting.
 
 ![schema of rstore local-first](./img/rstore-local-first-dark.svg){.dark-only}
 ![schema of rstore local-first](./img/rstore-local-first.svg){.light-only}


### PR DESCRIPTION
Appreciate your work on this project. 
This is a minor typo correction.

<!-- Thank you for contributing! -->

### Description

typo: client-size -> client-side

> In practice this means that all data reads in components are computed client-si~~z~~**d**e from the cache, including filtering and sorting.

---


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/rstore/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/rstore/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/rstore/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
