### PR TITLE
perf(vue): publish writeItems once

### DIFF
--- a/packages/vue/benchmark/README.md
+++ b/packages/vue/benchmark/README.md
@@ -1,0 +1,34 @@
+# `writeItems` publication benchmark
+
+From the repository root, after installing dependencies and building packages, run:
+
+```sh
+pnpm --filter @rstore/vue benchmark:write-items
+```
+
+The command exercises the real Vue cache runtime, the public collection `peekMany` query API, a
+Vue computed, and a synchronous watcher. It measures 100 and 1,000 deterministic flat items. Every
+warmup and measured sample creates an isolated store and cache. The two modes alternate execution
+order to reduce order bias.
+
+The optimized mode calls the public `cache.writeItems` API. The control reproduces the flat,
+non-staggered `processQueuedWriteItems` path at the parent of the optimization commit
+(`3db362ce95fe5aed6c1e461f6f455ccf50354ad1`): it calls the real `writeItemNow` once per item with
+`fromWriteItems: true`, then emits the one outer `afterCacheWrite` hook. The current no-batch
+`writeItemNow` path retains the legacy per-item reactive publication semantics. This is an exact
+control for the benchmarked flat, non-staggered case; it does not claim to reproduce legacy
+staggering, nested-relation settlement, or error handling.
+
+The JSON output contains Git revision and benchmark-source and helper-source provenance, environment metadata, every
+measured iteration, and median, p95, and MAD summaries. It also reports structural evidence. For
+1,000 items, the control must expose 1,000
+visible query transitions while the optimized path must expose one. The lower-level synchronous
+watcher/query counts are also asserted (the legacy write triggers three recomputations per item:
+pre-write invalidation, reactive assignment, and post-write invalidation). Both modes must produce
+the same final cache and query digest and exactly one outer hook.
+
+Timing values are descriptive, not pass/fail thresholds. The command fails only when final
+semantics, hook counts, or publication/recomputation counts differ. When reporting results, run the
+command from a clean worktree and fresh process, report the source and environment blocks plus the
+1,000-item medians with p95 and MAD. Raw per-iteration values in the same output are the provenance
+for the quoted summary; generated output is intentionally not checked in.

--- a/packages/vue/benchmark/publicationStore.ts
+++ b/packages/vue/benchmark/publicationStore.ts
@@ -1,0 +1,116 @@
+import type { Cache } from '@rstore/shared'
+import type { CacheRuntime } from '../src/cache/types'
+import assert from 'node:assert/strict'
+import { createStoreCore } from '@rstore/core'
+import { createHooks } from '@rstore/shared'
+import { createCollectionApi } from '../src/api/createCollectionApi'
+import { createCacheApi } from '../src/cache/api'
+import { createCacheRuntime, mark } from '../src/cache/context'
+import { writeItemNow } from '../src/cache/writes'
+
+/** Public write payload accepted by the historical flat control. */
+type WriteItemsParams = Parameters<Cache['writeItems']>[0]
+
+/** Queue cursor mirroring the historical synchronous writeItems path. */
+interface LegacyWriteItemsOperation {
+  /** Complete collection write payload. */
+  params: WriteItemsParams
+  /** Next item to apply. */
+  index: number
+}
+
+/**
+ * Reproduce the pre-change flat, non-staggered writeItems queue path from
+ * 3db362ce95fe5aed6c1e461f6f455ccf50354ad1. The real current writeItemNow
+ * retains that path whenever no CacheWriteBatch is supplied.
+ */
+export function legacyWriteItems(ctx: CacheRuntime, params: WriteItemsParams) {
+  const operation: LegacyWriteItemsOperation = { params, index: 0 }
+  ctx.state.queue.push(operation as unknown as CacheRuntime['state']['queue'][number])
+  ctx.isFlushingQueue = true
+  try {
+    while (operation.index < operation.params.items.length) {
+      const { key, value: item } = operation.params.items[operation.index]!
+      writeItemNow(ctx, {
+        collection: operation.params.collection,
+        key,
+        item,
+        meta: operation.params.meta,
+        fromWriteItems: true,
+      })
+      operation.index++
+    }
+
+    if (operation.params.marker) {
+      mark(ctx, operation.params.marker)
+    }
+    const store = ctx.getStore()
+    store.$hooks.callHookSync('afterCacheWrite', {
+      store,
+      meta: {},
+      collection: operation.params.collection,
+      result: operation.params.items,
+      marker: operation.params.marker,
+      operation: 'write',
+    })
+    ctx.state.queue.shift()
+  }
+  finally {
+    ctx.isFlushingQueue = false
+  }
+}
+
+/** Reject benchmark inputs outside the legacy control scope. */
+export function assertLegacyPreconditions(ctx: CacheRuntime) {
+  assert.equal(ctx.cacheStaggering, 0, 'The legacy control only models non-staggered writeItems')
+  assert.equal(ctx.state.paused, false, 'The legacy control expects an active cache')
+  assert.equal(ctx.isFlushingQueue, false, 'The legacy control expects an idle cache queue')
+  assert.equal(ctx.state.queue.length, 0, 'The legacy control expects an empty cache queue')
+}
+
+/** Build an isolated real cache with the public collection query API. */
+export async function createBenchmarkStore() {
+  let storeProxy: any
+  const runtime = createCacheRuntime({
+    getStore: () => storeProxy,
+    tombstoneGc: false,
+  })
+  const cache = createCacheApi(runtime)
+  const collectionApis = new Map<string, any>()
+
+  storeProxy = await createStoreCore({
+    schema: [{ name: 'BenchmarkItems' }],
+    plugins: [],
+    cache,
+    hooks: createHooks(),
+    syncImmediately: false,
+    transformStore: store => new Proxy(store, {
+      get(target, key) {
+        if (key === 'BenchmarkItems') {
+          if (!collectionApis.has(key)) {
+            collectionApis.set(key, createCollectionApi({
+              store: storeProxy,
+              getCollection: () => storeProxy.$collections[0],
+            }))
+          }
+          return collectionApis.get(key)
+        }
+        return Reflect.get(target, key)
+      },
+    }),
+  })
+
+  return { cache, runtime, store: storeProxy }
+}
+
+/** Generate independent deterministic expected data for one sample. */
+export function createItems(itemCount: number) {
+  return Array.from({ length: itemCount }, (_, index) => ({
+    key: index + 1,
+    value: {
+      id: index + 1,
+      group: index % 10,
+      name: `Item ${index + 1}`,
+    },
+  }))
+}

--- a/packages/vue/benchmark/write-items-publication.ts
+++ b/packages/vue/benchmark/write-items-publication.ts
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { arch, cpus, platform, release } from 'node:os'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { computed, watchSyncEffect } from 'vue'
+import { assertLegacyPreconditions, createBenchmarkStore, createItems, legacyWriteItems } from './publicationStore'
+
+const benchmarkName = '@rstore/vue writeItems atomic publication'
+const itemCounts = [100, 1000]
+const warmupIterations = 2
+const measuredIterations = 20
+const modes = ['legacy-per-item-control', 'optimized-public-writeItems'] as const
+
+type Mode = typeof modes[number]
+
+interface SampleResult {
+  durationMs: number
+  semanticDigest: string
+  watcherNotifications: number
+  visibleQueryTransitions: number
+  queryRecomputations: number
+  outerHookCalls: number
+}
+
+interface ModeMeasurements {
+  rawMs: number[]
+  structural: Omit<SampleResult, 'durationMs'>
+}
+
+interface ObservedCacheWrite {
+  collection: { name: string }
+  marker?: string
+  operation: string
+  result?: unknown
+}
+
+/** Normalize public wrapped rows for stable semantic comparison. */
+function normalizeItems(items: any[]) {
+  return items.map(item => ({
+    id: item.id,
+    group: item.group,
+    name: item.name,
+  }))
+}
+
+/** Measure one isolated write and assert its visible results and publications. */
+async function runSample(itemCount: number, mode: Mode): Promise<SampleResult> {
+  const { cache, runtime, store } = await createBenchmarkStore()
+  const collection = store.$collections[0]!
+  const items = createItems(itemCount)
+  const expected = items.map(({ value }) => value)
+  const marker = `benchmark-items-${itemCount}`
+  const writeParams = { collection, items, marker }
+  let queryRecomputations = 0
+  let watcherNotifications = 0
+  let visibleQueryTransitions = 0
+  let previousQueryLength: number | undefined
+  const observedCacheWrites: ObservedCacheWrite[] = []
+  const query = computed(() => {
+    queryRecomputations++
+    return store.BenchmarkItems.peekMany()
+  })
+  const stopWatcher = watchSyncEffect(() => {
+    const queryLength = query.value.length
+    if (previousQueryLength !== undefined) {
+      watcherNotifications++
+      if (queryLength !== previousQueryLength) {
+        visibleQueryTransitions++
+      }
+    }
+    previousQueryLength = queryLength
+  })
+  store.$hooks.hook('afterCacheWrite', (payload: ObservedCacheWrite) => {
+    if (payload.collection.name === collection.name) {
+      observedCacheWrites.push(payload)
+    }
+  })
+
+  try {
+    if (mode === 'legacy-per-item-control') {
+      assertLegacyPreconditions(runtime)
+    }
+    const startedAt = performance.now()
+    if (mode === 'optimized-public-writeItems') {
+      cache.writeItems(writeParams)
+    }
+    else {
+      legacyWriteItems(runtime, writeParams)
+    }
+    const durationMs = performance.now() - startedAt
+
+    const cacheItems = normalizeItems(cache.readItems({ collection, marker }))
+    const queryItems = normalizeItems(query.value)
+    assert.deepEqual(cacheItems, expected, `${mode} cache result differs from the deterministic input`)
+    assert.deepEqual(queryItems, expected, `${mode} query result differs from the deterministic input`)
+    assert.equal(observedCacheWrites.length, 1, `${mode} must emit exactly one afterCacheWrite hook`)
+    const [cacheWrite] = observedCacheWrites
+    assert.equal(cacheWrite!.collection, collection, `${mode} hook must identify the written collection`)
+    assert.equal(cacheWrite!.marker, marker, `${mode} hook must retain the batch marker`)
+    assert.equal(cacheWrite!.operation, 'write', `${mode} hook must report a write operation`)
+    assert.equal(cacheWrite!.result, items, `${mode} hook must retain the complete batch result`)
+
+    const expectedWatcherNotifications = mode === 'optimized-public-writeItems' ? 1 : itemCount * 3
+    const expectedQueryRecomputations = expectedWatcherNotifications + 1
+    const expectedVisibleTransitions = mode === 'optimized-public-writeItems' ? 1 : itemCount
+    assert.equal(watcherNotifications, expectedWatcherNotifications, `${mode} watcher notification count changed`)
+    assert.equal(queryRecomputations, expectedQueryRecomputations, `${mode} query recomputation count changed`)
+    assert.equal(visibleQueryTransitions, expectedVisibleTransitions, `${mode} visible query transition count changed`)
+
+    return {
+      durationMs,
+      semanticDigest: createHash('sha256').update(JSON.stringify(cacheItems)).digest('hex').slice(0, 16),
+      watcherNotifications,
+      visibleQueryTransitions,
+      queryRecomputations,
+      outerHookCalls: observedCacheWrites.length,
+    }
+  }
+  finally {
+    stopWatcher()
+    cache.dispose()
+  }
+}
+
+/** Alternate control and optimized order to reduce measurement bias. */
+function getModeOrder(iteration: number): Mode[] {
+  return iteration % 2 === 0 ? [...modes] : modes.toReversed()
+}
+
+/** Return the median from an already sorted nonempty sample. */
+function medianOfSorted(sorted: number[]) {
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!
+}
+
+/** Compute a median without mutating measured samples. */
+function median(values: number[]) {
+  return medianOfSorted(values.toSorted((a, b) => a - b))
+}
+
+/** Report timing spread without introducing timing pass criteria. */
+function summarize(values: number[]) {
+  const sorted = values.toSorted((a, b) => a - b)
+  const medianMs = medianOfSorted(sorted)
+  const absoluteDeviations = sorted.map(value => Math.abs(value - medianMs))
+  return {
+    medianMs,
+    p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1]!,
+    madMs: median(absoluteDeviations),
+    minMs: sorted[0]!,
+    maxMs: sorted.at(-1)!,
+  }
+}
+
+/** Round displayed timings while retaining the raw measurements for analysis. */
+function round(value: number) {
+  return Number(value.toFixed(3))
+}
+
+/** Round each timing summary field for JSON output. */
+function roundSummary(summary: ReturnType<typeof summarize>) {
+  return Object.fromEntries(Object.entries(summary).map(([key, value]) => [key, round(value)]))
+}
+
+/** Record Git and both benchmark source hashes for reproducibility. */
+function getSourceMetadata() {
+  const sourcePath = fileURLToPath(import.meta.url)
+  const git = (...args: string[]) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+  return {
+    gitHead: git('rev-parse', 'HEAD'),
+    worktreeDirty: git('status', '--porcelain', '--untracked-files=normal').length > 0,
+    benchmarkSourceSha256: createHash('sha256').update(readFileSync(sourcePath)).digest('hex'),
+    benchmarkHelperSourceSha256: createHash('sha256').update(readFileSync(new URL('./publicationStore.ts', import.meta.url))).digest('hex'),
+  }
+}
+
+/** Warm both modes, measure alternating samples, and require semantic parity. */
+async function runSize(itemCount: number) {
+  for (let iteration = 0; iteration < warmupIterations; iteration++) {
+    for (const mode of getModeOrder(iteration)) {
+      await runSample(itemCount, mode)
+    }
+  }
+
+  const measurements: Record<Mode, { rawMs: number[], structural?: ModeMeasurements['structural'] }> = {
+    'legacy-per-item-control': { rawMs: [], structural: undefined },
+    'optimized-public-writeItems': { rawMs: [], structural: undefined },
+  }
+
+  for (let iteration = 0; iteration < measuredIterations; iteration++) {
+    for (const mode of getModeOrder(iteration)) {
+      const sample = await runSample(itemCount, mode)
+      measurements[mode].rawMs.push(sample.durationMs)
+      const { durationMs: _, ...structural } = sample
+      if (measurements[mode].structural) {
+        assert.deepEqual(structural, measurements[mode].structural, `${mode} structural evidence changed between samples`)
+      }
+      measurements[mode].structural = structural
+    }
+  }
+
+  const legacy = measurements['legacy-per-item-control']
+  const optimized = measurements['optimized-public-writeItems']
+  assert(legacy.structural, 'Legacy control produced no measured structural evidence')
+  assert(optimized.structural, 'Optimized path produced no measured structural evidence')
+  assert.equal(legacy.structural.semanticDigest, optimized.structural.semanticDigest, 'Control and optimized cache/query results differ')
+  const legacySummary = summarize(legacy.rawMs)
+  const optimizedSummary = summarize(optimized.rawMs)
+
+  return {
+    itemCount,
+    structuralEvidence: {
+      'legacy-per-item-control': legacy.structural,
+      'optimized-public-writeItems': optimized.structural,
+    },
+    timings: {
+      'legacy-per-item-control': {
+        rawMs: legacy.rawMs.map(round),
+        summary: roundSummary(legacySummary),
+      },
+      'optimized-public-writeItems': {
+        rawMs: optimized.rawMs.map(round),
+        summary: roundSummary(optimizedSummary),
+      },
+      'medianSpeedup': round(legacySummary.medianMs / optimizedSummary.medianMs),
+    },
+  }
+}
+
+/** Run every configured size and emit machine-readable evidence. */
+async function main() {
+  const cpu = cpus()
+  const results = []
+  for (const itemCount of itemCounts) {
+    results.push(await runSize(itemCount))
+  }
+  const output = {
+    benchmark: benchmarkName,
+    methodology: {
+      itemCounts,
+      warmupIterations,
+      measuredIterations,
+      isolatedStatePerSample: true,
+      timingAssertions: false,
+    },
+    source: getSourceMetadata(),
+    environment: {
+      node: process.version,
+      v8: process.versions.v8,
+      platform: platform(),
+      release: release(),
+      arch: arch(),
+      cpu: cpu[0]?.model ?? 'unknown',
+      logicalCpuCount: cpu.length,
+    },
+    results,
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error)
+  process.stderr.write(`${message}\n`)
+  process.exitCode = 1
+})

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,6 +32,7 @@
     "skills"
   ],
   "scripts": {
+    "benchmark:write-items": "vite-node benchmark/write-items-publication.ts",
     "build": "unbuild",
     "dev": "unbuild --stub && printf \"export * from '../src/index'\" > ./dist/index.mjs",
     "prepack": "node ../../scripts/sync-dep-skills.mjs .",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "typescript": "catalog:",
     "unbuild": "catalog:",
+    "vite-node": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:"
   }

--- a/packages/vue/src/cache/api.ts
+++ b/packages/vue/src/cache/api.ts
@@ -7,7 +7,7 @@ import { rebuildIndexes } from './indexes'
 import { ensureLayersForCollection, getStateForCollection } from './layers'
 import { applyMutationToCache } from './mutations'
 import { clearQueryStateForCollection } from './queryState'
-import { enqueueOperation, flushQueuedOperations } from './queue'
+import { enqueueOperation, enqueueWriteItems, flushQueuedOperations } from './queue'
 import { resolveRelationWriteParams } from './relationWrite'
 import { garbageCollectItem, getWrappedItem } from './wrapped'
 
@@ -30,7 +30,7 @@ export function createCacheApi<
       enqueueOperation(ctx, { type: 'writeItem', params })
     },
     writeItems(params) {
-      enqueueOperation(ctx, { type: 'writeItems', params, index: 0 })
+      enqueueWriteItems(ctx, params)
     },
     writeItemForRelation(params) {
       enqueueOperation(ctx, { type: 'writeItem', params: resolveRelationWriteParams(ctx, params) })

--- a/packages/vue/src/cache/context.ts
+++ b/packages/vue/src/cache/context.ts
@@ -63,8 +63,13 @@ export function ensureCollectionStateCacheReactivityMarker(ctx: CacheRuntime, co
 
 /** Drop a cached overlay state and notify reactive readers. */
 export function invalidateCollectionStateCache(ctx: CacheRuntime, collectionName: string) {
-  ctx.collectionStateCache.delete(collectionName)
+  evictCollectionStateCache(ctx, collectionName)
   ensureCollectionStateCacheReactivityMarker(ctx, collectionName).value++
+}
+
+/** Drop a cached overlay state without notifying reactive readers. */
+export function evictCollectionStateCache(ctx: CacheRuntime, collectionName: string) {
+  ctx.collectionStateCache.delete(collectionName)
 }
 
 /** Build the cache key for a wrapped item proxy. */

--- a/packages/vue/src/cache/indexes.ts
+++ b/packages/vue/src/cache/indexes.ts
@@ -1,7 +1,7 @@
 import type { Collection, CollectionDefaults, ResolvedCollection, StoreSchema } from '@rstore/shared'
-import type { CacheRuntime } from './types'
+import type { CacheRuntime, CacheWriteBatch } from './types'
 import { isKeyDefined } from '@rstore/core'
-import { ref, toValue } from 'vue'
+import { ref, toRaw, toValue } from 'vue'
 import { getCollectionIndex } from './context'
 
 /** Reads the effective collection state, including every active cache layer. */
@@ -54,6 +54,7 @@ export function updateItemIndexes<TCollection extends Collection>(
   key: string | number,
   previousData: any,
   newData: any = {},
+  batch?: CacheWriteBatch,
 ) {
   for (const [indexKey, indexFields] of collection.indexes) {
     if (!indexFields.some(f => f in newData && (!previousData || newData[f] !== previousData[f]))) {
@@ -67,7 +68,8 @@ export function updateItemIndexes<TCollection extends Collection>(
         const previousValue = values.join(':')
         const existingKeys = index.get(previousValue)
         if (existingKeys) {
-          existingKeys.value.delete(String(key))
+          const keys = batch ? toRaw(existingKeys.value) : existingKeys.value
+          keys.delete(String(key))
         }
       }
     }
@@ -83,9 +85,9 @@ export function updateItemIndexes<TCollection extends Collection>(
         existingKeys = ref(new Set())
         index.set(newValue, existingKeys)
       }
-      // Index membership follows object-backed cache identity, including keys
-      // restored from a snapshot and later addressed through numeric APIs.
-      existingKeys.value.add(String(key))
+      // Keep index membership aligned with object-backed cache identity.
+      const keys = batch ? toRaw(existingKeys.value) : existingKeys.value
+      keys.add(String(key))
     }
   }
 }

--- a/packages/vue/src/cache/layers.ts
+++ b/packages/vue/src/cache/layers.ts
@@ -2,11 +2,13 @@ import type { CacheLayer } from '@rstore/shared'
 import type { Ref } from 'vue'
 import type { CacheRuntime } from './types'
 import { shallowRef } from 'vue'
-import { ensureCollectionStateCacheReactivityMarker, invalidateCollectionStateCache } from './context'
+import { ensureCollectionRef, ensureCollectionStateCacheReactivityMarker, invalidateCollectionStateCache } from './context'
 import { updateItemIndexes } from './indexes'
 
 /** Read a collection state with active non-skipped layers applied. */
 export function getStateForCollection(ctx: CacheRuntime, collectionName: string) {
+  const collectionState = ensureCollectionRef(ctx, collectionName).value
+
   // eslint-disable-next-line ts/no-unused-expressions
   ensureCollectionStateCacheReactivityMarker(ctx, collectionName).value
 
@@ -16,7 +18,7 @@ export function getStateForCollection(ctx: CacheRuntime, collectionName: string)
   }
 
   let copied = false
-  let result = ctx.state.collections[collectionName]?.value ?? {}
+  let result = collectionState
   const collectionLayersRef = ctx.layers[collectionName]
   if (collectionLayersRef) {
     const collectionLayers = collectionLayersRef.value

--- a/packages/vue/src/cache/mutations.ts
+++ b/packages/vue/src/cache/mutations.ts
@@ -2,7 +2,7 @@ import type { ApplyMutationOptions, ApplyMutationResult, Collection, CollectionD
 import type { CacheRuntime } from './types'
 import { isKeyDefined } from '@rstore/core'
 import { getMutationItemKey, unwrapMutationItem } from '@rstore/shared'
-import { enqueueOperation } from './queue'
+import { enqueueOperation, enqueueWriteItems } from './queue'
 
 /** Apply a mutation-shaped cache update without emitting mutation hooks. */
 export function applyMutationToCache<TCollection extends Collection, TCollectionDefaults extends CollectionDefaults, TSchema extends StoreSchema>(
@@ -51,14 +51,10 @@ function applyWriteMutation<TCollection extends Collection, TCollectionDefaults 
     })
   }
   else if (writes.length) {
-    enqueueOperation(ctx, {
-      type: 'writeItems',
-      params: {
-        collection: params.collection,
-        items: writes,
-        meta: params.meta,
-      },
-      index: 0,
+    enqueueWriteItems(ctx, {
+      collection: params.collection,
+      items: writes,
+      meta: params.meta,
     })
   }
 

--- a/packages/vue/src/cache/queue.ts
+++ b/packages/vue/src/cache/queue.ts
@@ -1,7 +1,14 @@
-import type { CacheRuntime, QueuedOperation } from './types'
-import { mark } from './context'
+import type { CacheRuntime, CacheWriteBatch, QueuedOperation } from './types'
+import { triggerRef } from 'vue'
+import { ensureCollectionRef, evictCollectionStateCache, mark } from './context'
 import { addLayerNow, removeLayer } from './layers'
 import { clearNow, deleteItemNow, setStateNow, writeItemNow } from './writes'
+
+/** Completed queue entry whose observer errors must not replay the write. */
+interface CompletedOperation {
+  /** Observer errors raised after data was written successfully. */
+  settlementErrors: unknown[]
+}
 
 /** Enqueue an operation and flush it immediately when the cache is active. */
 export function enqueueOperation(ctx: CacheRuntime, operation: QueuedOperation) {
@@ -11,6 +18,19 @@ export function enqueueOperation(ctx: CacheRuntime, operation: QueuedOperation) 
   }
 }
 
+/** Enqueue a collection write batch with its publication state. */
+export function enqueueWriteItems(ctx: CacheRuntime, params: Extract<QueuedOperation, { type: 'writeItems' }>['params']) {
+  enqueueOperation(ctx, {
+    type: 'writeItems',
+    params,
+    index: 0,
+    batch: {
+      affectedCollections: new Set(),
+      deferredAfterCacheWrites: [],
+    },
+  })
+}
+
 /** Flush queued cache operations while respecting pause and staggering state. */
 export function flushQueuedOperations(ctx: CacheRuntime) {
   if (ctx.isFlushingQueue || ctx.state.paused) {
@@ -18,14 +38,27 @@ export function flushQueuedOperations(ctx: CacheRuntime) {
   }
 
   ctx.isFlushingQueue = true
+  const deferredErrors: unknown[] = []
   try {
     while (ctx.state.queue.length) {
       const operation = ctx.state.queue[0]!
-      if (!processQueuedOperation(ctx, operation)) {
+      let result: boolean | CompletedOperation
+      try {
+        result = processQueuedOperation(ctx, operation)
+      }
+      catch (error) {
+        throwWithSecondaryErrors(error, deferredErrors)
+      }
+      if (!result) {
+        throwSettlementErrors(deferredErrors)
         return
       }
       ctx.state.queue.shift()
+      if (result !== true) {
+        deferredErrors.push(...result.settlementErrors)
+      }
     }
+    throwSettlementErrors(deferredErrors)
   }
   finally {
     ctx.isFlushingQueue = false
@@ -74,34 +107,105 @@ function processQueuedWriteItems(ctx: CacheRuntime, operation: Extract<QueuedOpe
   if (operation.params.meta?.$canPublishQuery?.() === false) {
     return true
   }
-  while (operation.index < operation.params.items.length) {
-    if (!canProcessQueuedWrite(ctx)) {
-      return false
+  try {
+    while (operation.index < operation.params.items.length) {
+      if (!canProcessQueuedWrite(ctx)) {
+        return false
+      }
+      const { key, value: item } = operation.params.items[operation.index]!
+      writeItemNow(ctx, {
+        collection: operation.params.collection,
+        key,
+        item,
+        meta: operation.params.meta,
+        fromWriteItems: true,
+        batch: operation.batch,
+      })
+      operation.index++
+      consumeQueuedWrite(ctx)
     }
-    const { key, value: item } = operation.params.items[operation.index]!
-    writeItemNow(ctx, {
-      collection: operation.params.collection,
-      key,
-      item,
-      meta: operation.params.meta,
-      fromWriteItems: true,
-    })
-    operation.index++
-    consumeQueuedWrite(ctx)
+  }
+  catch (error) {
+    throwWithSecondaryErrors(error, settleWriteBatch(ctx, operation.batch))
   }
   if (operation.params.marker) {
     mark(ctx, operation.params.marker)
   }
+
+  const settlementErrors = settleWriteBatch(ctx, operation.batch)
   const store = ctx.getStore()
-  store.$hooks.callHookSync('afterCacheWrite', {
-    store,
-    meta: {},
-    collection: operation.params.collection,
-    result: operation.params.items,
-    marker: operation.params.marker,
-    operation: 'write',
-  })
-  return true
+  try {
+    store.$hooks.callHookSync('afterCacheWrite', {
+      store,
+      meta: {},
+      collection: operation.params.collection,
+      result: operation.params.items,
+      marker: operation.params.marker,
+      operation: 'write',
+    })
+  }
+  catch (error) {
+    settlementErrors.push(error)
+  }
+  return { settlementErrors }
+}
+
+/** Publish data before invoking deferred nested hooks, collecting observer failures. */
+function settleWriteBatch(ctx: CacheRuntime, batch: CacheWriteBatch) {
+  const errors = publishWriteBatch(ctx, batch)
+  const deferredAfterCacheWrites = batch.deferredAfterCacheWrites.splice(0)
+  const store = ctx.getStore()
+  for (const payload of deferredAfterCacheWrites) {
+    try {
+      store.$hooks.callHookSync('afterCacheWrite', payload)
+    }
+    catch (error) {
+      errors.push(error)
+    }
+  }
+  return errors
+}
+
+/** Notify each affected collection once, continuing past failing observers. */
+function publishWriteBatch(ctx: CacheRuntime, batch: CacheWriteBatch) {
+  const errors: unknown[] = []
+  try {
+    for (const collectionName of batch.affectedCollections) {
+      evictCollectionStateCache(ctx, collectionName)
+      try {
+        triggerRef(ensureCollectionRef(ctx, collectionName))
+      }
+      catch (error) {
+        errors.push(error)
+      }
+    }
+  }
+  finally {
+    batch.affectedCollections.clear()
+  }
+  return errors
+}
+
+/** Keep the write failure primary when publication also fails. */
+function throwWithSecondaryErrors(primaryError: unknown, secondaryErrors: unknown[]): never {
+  if (!secondaryErrors.length) {
+    throw primaryError
+  }
+  throw new AggregateError(
+    [primaryError, ...secondaryErrors],
+    'Cache operation failed and batch settlement reported additional errors',
+    { cause: primaryError },
+  )
+}
+
+/** Surface observer failures after completed queue entries are removed. */
+function throwSettlementErrors(errors: unknown[]) {
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Cache batch settlement reported multiple errors', { cause: errors[0] })
+  }
 }
 
 function processQueuedDelete(ctx: CacheRuntime, operation: Extract<QueuedOperation, { type: 'deleteItem' }>) {

--- a/packages/vue/src/cache/queue.ts
+++ b/packages/vue/src/cache/queue.ts
@@ -103,9 +103,13 @@ function processQueuedWriteItem(ctx: CacheRuntime, operation: Extract<QueuedOper
 }
 
 function processQueuedWriteItems(ctx: CacheRuntime, operation: Extract<QueuedOperation, { type: 'writeItems' }>) {
-  // Discard stale pages together with their marker and notification.
+  // A stale page that has not started can be discarded without publication.
+  // Once a staggered slice wrote raw state, settle it so readers and nested
+  // hooks cannot remain behind the cache. The marker and outer hook stay stale.
   if (operation.params.meta?.$canPublishQuery?.() === false) {
-    return true
+    return operation.index === 0
+      ? true
+      : { settlementErrors: settleWriteBatch(ctx, operation.batch) }
   }
   try {
     while (operation.index < operation.params.items.length) {

--- a/packages/vue/src/cache/types.ts
+++ b/packages/vue/src/cache/types.ts
@@ -1,5 +1,5 @@
 import type { TombstoneStore } from '@rstore/core'
-import type { Cache, CacheLayer, Collection, CollectionDefaults, CustomCacheState, CustomHookMeta, FieldTimestamps, ResolvedCollection, ResolvedCollectionItem, StoreSchema, WrappedItem } from '@rstore/shared'
+import type { Cache, CacheHookDefinitions, CacheLayer, Collection, CollectionDefaults, CustomCacheState, CustomHookMeta, FieldTimestamps, ResolvedCollection, ResolvedCollectionItem, StoreSchema, WrappedItem } from '@rstore/shared'
 import type { Ref } from 'vue'
 import type { WrappedItemMetadata } from '../item'
 import type { VueStore } from '../store'
@@ -7,12 +7,23 @@ import type { VueStore } from '../store'
 /** Cache operations delayed while the cache is paused or write staggering is active. */
 export type QueuedOperation
   = | { type: 'writeItem', params: Parameters<Cache['writeItem']>[0] }
-    | { type: 'writeItems', params: Parameters<Cache['writeItems']>[0], index: number }
+    | { type: 'writeItems', params: Parameters<Cache['writeItems']>[0], index: number, batch: CacheWriteBatch }
     | { type: 'deleteItem', params: Parameters<Cache['deleteItem']>[0] }
     | { type: 'addLayer', layer: Parameters<Cache['addLayer']>[0] }
     | { type: 'removeLayer', layerId: Parameters<Cache['removeLayer']>[0] }
     | { type: 'setState', state: CustomCacheState }
     | { type: 'clear' }
+
+/** Public hook payload retained until its complete batch becomes visible. */
+type AfterCacheWritePayload = Parameters<CacheHookDefinitions<StoreSchema, CollectionDefaults>['afterCacheWrite']>[0]
+
+/** Reactive collection publications and nested hooks deferred until a writeItems operation settles. */
+export interface CacheWriteBatch {
+  /** Collections needing one reactive publication at settlement. */
+  affectedCollections: Set<string>
+  /** Nested write notifications delivered after collection publication. */
+  deferredAfterCacheWrites: AfterCacheWritePayload[]
+}
 
 /** Reactive state owned by the Vue cache implementation. */
 export interface InternalCacheState {

--- a/packages/vue/src/cache/writePublication.ts
+++ b/packages/vue/src/cache/writePublication.ts
@@ -1,0 +1,20 @@
+import type { CacheRuntime, CacheWriteBatch } from './types'
+import { toRaw } from 'vue'
+import { evictCollectionStateCache, invalidateCollectionStateCache } from './context'
+
+/** Evict derived state and defer notifications until the batch settles. */
+export function invalidateCollectionWrite(ctx: CacheRuntime, collectionName: string, batch?: CacheWriteBatch) {
+  if (batch) {
+    evictCollectionStateCache(ctx, collectionName)
+    batch.affectedCollections.add(collectionName)
+  }
+  else {
+    invalidateCollectionStateCache(ctx, collectionName)
+  }
+}
+
+/** Write silently during a batch, or notify immediately for a single write. */
+export function setCollectionItem(collectionState: Record<string | number, any>, key: string | number, value: any, batch?: CacheWriteBatch) {
+  const target = batch ? toRaw(collectionState) : collectionState
+  target[key] = value
+}

--- a/packages/vue/src/cache/writes.ts
+++ b/packages/vue/src/cache/writes.ts
@@ -1,6 +1,6 @@
 import type { Cache, Collection, CollectionDefaults, CustomCacheState, ResolvedCollection, StoreSchema } from '@rstore/shared'
 import type { Ref } from 'vue'
-import type { CacheRuntime } from './types'
+import type { CacheRuntime, CacheWriteBatch } from './types'
 import { mergeItemFields, shouldResurrect } from '@rstore/core'
 import { pickNonSpecialProps } from '@rstore/shared'
 import { markRaw, ref, shallowRef } from 'vue'
@@ -9,6 +9,7 @@ import { restoreCausality } from './hydration'
 import { removeItemIndexes, updateItemIndexes } from './indexes'
 import { clearAllQueryState } from './queryState'
 import { resolveRelationWriteParams } from './relationWrite'
+import { invalidateCollectionWrite, setCollectionItem } from './writePublication'
 
 /** Delete an item immediately without going through the pause queue. */
 export function deleteItemNow<TCollection extends Collection>(
@@ -51,12 +52,16 @@ export function writeItemForRelationNow({
   relation,
   childItem,
   meta,
-}: Parameters<Cache['writeItemForRelation']>[0] & { ctx: CacheRuntime }) {
-  writeItemNow(ctx, resolveRelationWriteParams(ctx, { parentCollection, relationKey, relation, childItem, meta }))
+  batch,
+}: Parameters<Cache['writeItemForRelation']>[0] & { ctx: CacheRuntime, batch?: CacheWriteBatch }) {
+  writeItemNow(ctx, {
+    ...resolveRelationWriteParams(ctx, { parentCollection, relationKey, relation, childItem, meta }),
+    batch,
+  })
 }
 
 /** Write an item immediately without going through the pause queue. */
-export function writeItemNow(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0]) {
+export function writeItemNow(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0] & { batch?: CacheWriteBatch }) {
   const { collection, key, item, marker, fromWriteItems, meta } = params
   const tomb = ctx.state.tombstones.get(collection.name, key)
   if (tomb) {
@@ -66,16 +71,16 @@ export function writeItemNow(ctx: CacheRuntime, params: Parameters<Cache['writeI
     ctx.state.tombstones.clear(collection.name, key)
   }
 
-  invalidateCollectionStateCache(ctx, collection.name)
+  invalidateCollectionWrite(ctx, collection.name, params.batch)
 
   const collectionState = ensureCollectionRef(ctx, collection.name).value
   if (Object.isFrozen(item)) {
-    collectionState[key] = item
+    setCollectionItem(collectionState, key, item, params.batch)
   }
   else {
     writeMutableItem(ctx, params, collectionState)
   }
-  invalidateCollectionStateCache(ctx, collection.name)
+  invalidateCollectionWrite(ctx, collection.name, params.batch)
 
   if (marker) {
     mark(ctx, marker)
@@ -88,7 +93,7 @@ export function writeItemNow(ctx: CacheRuntime, params: Parameters<Cache['writeI
 
   if (!fromWriteItems) {
     const store = ctx.getStore()
-    store.$hooks.callHookSync('afterCacheWrite', {
+    const payload: CacheWriteBatch['deferredAfterCacheWrites'][number] = {
       store,
       meta: {},
       collection,
@@ -96,7 +101,13 @@ export function writeItemNow(ctx: CacheRuntime, params: Parameters<Cache['writeI
       result: [item],
       marker,
       operation: 'write',
-    })
+    }
+    if (params.batch) {
+      params.batch.deferredAfterCacheWrites.push(payload)
+    }
+    else {
+      store.$hooks.callHookSync('afterCacheWrite', payload)
+    }
   }
 }
 
@@ -176,7 +187,7 @@ export function clearNow(ctx: CacheRuntime) {
   })
 }
 
-function writeMutableItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0], collectionState: Record<string | number, any>) {
+function writeMutableItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0] & { batch?: CacheWriteBatch }, collectionState: Record<string | number, any>) {
   const { collection, key, item } = params
   const rawData = pickNonSpecialProps(item, true)
   const data: Record<string, any> = {}
@@ -192,8 +203,8 @@ function writeMutableItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem
 
   const existing = collectionState[key]
   if (!existing) {
-    updateItemIndexes(ctx, collection, key, undefined, data)
-    collectionState[key] = shallowRef(markRaw(data))
+    updateItemIndexes(ctx, collection, key, undefined, data, params.batch)
+    setCollectionItem(collectionState, key, shallowRef(markRaw(data)), params.batch)
     if (params.fieldTimestamps) {
       ensureCollectionTimestamps(ctx, collection.name).set(key, { ...params.fieldTimestamps })
     }
@@ -202,15 +213,15 @@ function writeMutableItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem
     mergeTimestampedItem(ctx, params, collectionState, existing, data)
   }
   else {
-    updateItemIndexes(ctx, collection, key, existing, data)
-    collectionState[key] = markRaw({
+    updateItemIndexes(ctx, collection, key, existing, data, params.batch)
+    setCollectionItem(collectionState, key, markRaw({
       ...existing,
       ...data,
-    })
+    }), params.batch)
   }
 }
 
-function writeRelationField(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0], field: string, rawItem: any) {
+function writeRelationField(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0] & { batch?: CacheWriteBatch }, field: string, rawItem: any) {
   const relation = params.collection.relations[field]
   if (!rawItem || !relation) {
     return
@@ -231,11 +242,12 @@ function writeRelationField(ctx: CacheRuntime, params: Parameters<Cache['writeIt
       relation,
       childItem: nestedItem,
       meta: params.meta,
+      batch: params.batch,
     })
   }
 }
 
-function mergeTimestampedItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0], collectionState: Record<string | number, any>, existing: any, data: any) {
+function mergeTimestampedItem(ctx: CacheRuntime, params: Parameters<Cache['writeItem']>[0] & { batch?: CacheWriteBatch }, collectionState: Record<string | number, any>, existing: any, data: any) {
   const collectionTs = ensureCollectionTimestamps(ctx, params.collection.name)
   const localTimestamps = collectionTs.get(params.key) ?? {}
   const { merged, mergedTimestamps, conflicts } = mergeItemFields(
@@ -245,9 +257,9 @@ function mergeTimestampedItem(ctx: CacheRuntime, params: Parameters<Cache['write
     params.fieldTimestamps!,
   )
   // Rejected remote fields must not change relation membership.
-  updateItemIndexes(ctx, params.collection, params.key, existing, merged)
+  updateItemIndexes(ctx, params.collection, params.key, existing, merged, params.batch)
   collectionTs.set(params.key, mergedTimestamps)
-  collectionState[params.key] = markRaw(merged)
+  setCollectionItem(collectionState, params.key, markRaw(merged), params.batch)
 
   if (conflicts.length > 0) {
     const store = ctx.getStore()

--- a/packages/vue/test/integration/cache/publication-errors.spec.ts
+++ b/packages/vue/test/integration/cache/publication-errors.spec.ts
@@ -1,0 +1,154 @@
+import { createTestStore as createStore } from '#test-utils/store/integrationStore'
+import { describe, expect, it, vi } from 'vitest'
+import { watchSyncEffect } from 'vue'
+
+describe('cache writeItems', () => {
+  it('publishes partial state and preserves write and settlement errors', async () => {
+    const store = await createStore({
+      schema: [
+        {
+          name: 'TestCollection',
+          relations: {
+            related: { to: { RelatedCollection: { on: { id: 'relatedId' } } }, many: false },
+          },
+        },
+        { name: 'RelatedCollection' },
+        { name: 'IndependentCollection' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    const independentCollection = store.$collections[2]!
+    const items: Array<{ key: number, value: any }> = [
+      { key: 1, value: { id: 1, name: 'Written before failure' } },
+      {
+        key: 2,
+        value: {
+          id: 2,
+          relatedId: 11,
+          related: [{ id: 11, name: 'Invalid to-one relation value' }],
+        },
+      },
+    ]
+    const observedLengths: number[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let throwOnPublication = true
+    const stop = watchSyncEffect(() => {
+      const length = cache.readItems({ collection }).length
+      observedLengths.push(length)
+      if (length > 0 && throwOnPublication) {
+        throwOnPublication = false
+        throw new Error('reader failed during partial publication')
+      }
+    })
+
+    try {
+      let caught: unknown
+      try {
+        cache.writeItems({ collection, items })
+      }
+      catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(AggregateError)
+      const aggregate = caught as AggregateError
+      expect(aggregate.errors.map(error => (error as Error).message)).toEqual([
+        'Expected object for relation TestCollection.related',
+        'reader failed during partial publication',
+      ])
+      expect((aggregate.cause as Error).message).toBe('Expected object for relation TestCollection.related')
+      expect(cache.readItem({ collection, key: 1 })).toEqual({ id: 1, name: 'Written before failure' })
+      expect(observedLengths).toEqual([0, 1])
+
+      items[1]!.value.related = { id: 11, name: 'Valid on retry' }
+      cache.writeItem({
+        collection: independentCollection,
+        key: 1,
+        item: { id: 1, name: 'Later queued write' },
+      })
+
+      expect(cache.readItem({ collection, key: 2 })).toMatchObject({ id: 2, relatedId: 11 })
+      expect(cache.readItem({ collection: independentCollection, key: 1 })).toEqual({ id: 1, name: 'Later queued write' })
+      expect(observedLengths).toEqual([0, 1, 2])
+    }
+    finally {
+      stop()
+      warn.mockRestore()
+    }
+  })
+
+  it('does not emit the outer hook on partial failure and emits it once after retry publication', async () => {
+    const store = await createStore({
+      schema: [
+        {
+          name: 'TestCollection',
+          relations: {
+            related: { to: { RelatedCollection: { on: { id: 'relatedId' } } }, many: false },
+          },
+        },
+        { name: 'RelatedCollection' },
+        { name: 'IndependentCollection' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    const relatedCollection = store.$collections[1]!
+    const independentCollection = store.$collections[2]!
+    const items: Array<{ key: number, value: any }> = [
+      { key: 1, value: { id: 1, name: 'Written before failure' } },
+      {
+        key: 2,
+        value: {
+          id: 2,
+          relatedId: 11,
+          related: [{ id: 11, name: 'Invalid to-one relation value' }],
+        },
+      },
+    ]
+    const observedLengths: number[] = []
+    const observedRelatedLengths: number[] = []
+    const outerHookLengths: number[] = []
+    const stop = watchSyncEffect(() => {
+      observedLengths.push(cache.readItems({ collection }).length)
+    })
+    const stopRelated = watchSyncEffect(() => {
+      observedRelatedLengths.push(cache.readItems({ collection: relatedCollection }).length)
+    })
+    store.$hooks.hook('afterCacheWrite', ({ collection: hookCollection, result }) => {
+      if (hookCollection.name === collection.name && Array.isArray(result) && result.length === items.length) {
+        outerHookLengths.push(observedLengths.at(-1)!)
+      }
+    })
+
+    try {
+      expect(() => cache.writeItems({ collection, items }))
+        .toThrow('Expected object for relation TestCollection.related')
+
+      expect(observedLengths).toEqual([0, 1])
+      expect(observedRelatedLengths).toEqual([0])
+      expect(outerHookLengths).toEqual([])
+
+      items[1]!.value.related = { id: 11, name: 'Valid on retry' }
+      cache.writeItem({
+        collection: independentCollection,
+        key: 1,
+        item: { id: 1, name: 'Later queued write' },
+      })
+
+      const retriedItem = cache.readItem({ collection, key: 2 }) as any
+      expect(retriedItem).toMatchObject({ id: 2, relatedId: 11 })
+      expect(retriedItem.related).toMatchObject({ id: 11, name: 'Valid on retry' })
+      expect(cache.readItem({ collection: independentCollection, key: 1 })).toEqual({ id: 1, name: 'Later queued write' })
+      expect(observedLengths).toEqual([0, 1, 2])
+      expect(observedRelatedLengths).toEqual([0, 1])
+      expect(outerHookLengths).toEqual([2])
+    }
+    finally {
+      stop()
+      stopRelated()
+    }
+  })
+})

--- a/packages/vue/test/integration/cache/publication-indexes.spec.ts
+++ b/packages/vue/test/integration/cache/publication-indexes.spec.ts
@@ -1,0 +1,77 @@
+import { createTestStore as createStore } from '#test-utils/store/integrationStore'
+import { describe, expect, it } from 'vitest'
+import { watchSyncEffect } from 'vue'
+
+describe('cache writeItems', () => {
+  it('publishes a multi-result applyMutation once to a warmed reader', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    expect(cache.readItems({ collection })).toEqual([])
+    const observedLengths: number[] = []
+    const stop = watchSyncEffect(() => {
+      observedLengths.push(cache.readItems({ collection }).length)
+    })
+
+    try {
+      const result = cache.applyMutation({
+        collection,
+        mutation: 'create',
+        results: [
+          { id: 1, name: 'First' },
+          { id: 2, name: 'Second' },
+        ],
+      })
+
+      expect(result).toEqual({ written: [1, 2], deleted: [], skipped: 0 })
+      expect(observedLengths).toEqual([0, 2])
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('publishes index changes once after the batch is complete', async () => {
+    const store = await createStore({
+      schema: [
+        {
+          name: 'Author',
+          relations: {
+            posts: { to: { Post: { on: { authorId: 'id' } } }, many: true },
+          },
+        },
+        { name: 'Post' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const postCollection = store.$collections.find(collection => collection.name === 'Post')!
+    cache.writeItem({ collection: postCollection, key: 1, item: { id: 1, title: 'First', authorId: 'a1' } })
+    const observedIds: number[][] = []
+    const stop = watchSyncEffect(() => {
+      observedIds.push(cache.readItems({
+        collection: postCollection,
+        indexKey: 'authorId',
+        indexValue: 'a1',
+      }).map(item => item.id))
+    })
+
+    try {
+      cache.writeItems({
+        collection: postCollection,
+        items: [
+          { key: 1, value: { authorId: 'a2' } },
+          { key: 2, value: { id: 2, title: 'Second', authorId: 'a1' } },
+        ],
+      })
+
+      expect(observedIds).toEqual([[1], [2]])
+    }
+    finally {
+      stop()
+    }
+  })
+})

--- a/packages/vue/test/integration/cache/publication-queue-errors.spec.ts
+++ b/packages/vue/test/integration/cache/publication-queue-errors.spec.ts
@@ -1,0 +1,92 @@
+import { createTestStore as createStore } from '#test-utils/store/integrationStore'
+import { describe, expect, it, vi } from 'vitest'
+import { watchSyncEffect } from 'vue'
+
+describe('cache writeItems', () => {
+  it('drains a paused later write before surfacing final publication failure', async () => {
+    const store = await createStore({
+      schema: [
+        { name: 'BatchCollection' },
+        { name: 'LaterCollection' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const batchCollection = store.$collections[0]!
+    const laterCollection = store.$collections[1]!
+    const observedLengths: number[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let throwOnPublication = true
+    const stop = watchSyncEffect(() => {
+      const length = cache.readItems({ collection: batchCollection }).length
+      observedLengths.push(length)
+      if (length > 0 && throwOnPublication) {
+        throwOnPublication = false
+        throw new Error('final publication failed')
+      }
+    })
+
+    try {
+      cache.pause()
+      cache.writeItems({
+        collection: batchCollection,
+        items: [
+          { key: 1, value: { id: 1 } },
+          { key: 2, value: { id: 2 } },
+        ],
+      })
+      cache.writeItem({ collection: laterCollection, key: 1, item: { id: 1, name: 'Later' } })
+
+      expect(() => cache.resume()).toThrow('final publication failed')
+
+      expect(observedLengths).toEqual([0, 2])
+      expect(cache.readItem({ collection: laterCollection, key: 1 })).toEqual({ id: 1, name: 'Later' })
+
+      cache.writeItem({ collection: laterCollection, key: 2, item: { id: 2, name: 'Still progresses' } })
+      expect(cache.readItem({ collection: laterCollection, key: 2 })).toEqual({ id: 2, name: 'Still progresses' })
+    }
+    finally {
+      stop()
+      warn.mockRestore()
+    }
+  })
+
+  it('runs a throwing outer hook once without replaying or stalling the queue', async () => {
+    const store = await createStore({
+      schema: [
+        { name: 'BatchCollection' },
+        { name: 'LaterCollection' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const batchCollection = store.$collections[0]!
+    const laterCollection = store.$collections[1]!
+    let outerHookCalls = 0
+    store.$hooks.hook('afterCacheWrite', ({ collection, result }) => {
+      if (collection.name === batchCollection.name && Array.isArray(result) && result.length === 2) {
+        outerHookCalls++
+        throw new Error('outer hook failed')
+      }
+    })
+
+    cache.pause()
+    cache.writeItems({
+      collection: batchCollection,
+      items: [
+        { key: 1, value: { id: 1 } },
+        { key: 2, value: { id: 2 } },
+      ],
+    })
+    cache.writeItem({ collection: laterCollection, key: 1, item: { id: 1, name: 'Already queued' } })
+
+    expect(() => cache.resume()).toThrow('outer hook failed')
+
+    expect(outerHookCalls).toBe(1)
+    expect(cache.readItem({ collection: laterCollection, key: 1 })).toEqual({ id: 1, name: 'Already queued' })
+
+    cache.writeItem({ collection: laterCollection, key: 2, item: { id: 2, name: 'Still progresses' } })
+    expect(cache.readItem({ collection: laterCollection, key: 2 })).toEqual({ id: 2, name: 'Still progresses' })
+    expect(outerHookCalls).toBe(1)
+  })
+})

--- a/packages/vue/test/integration/cache/publication-staggering.spec.ts
+++ b/packages/vue/test/integration/cache/publication-staggering.spec.ts
@@ -1,0 +1,167 @@
+import { createTestStore as createStore } from '#test-utils/store/integrationStore'
+import { describe, expect, it, vi } from 'vitest'
+import { watchSyncEffect } from 'vue'
+
+describe('cache writeItems', () => {
+  it('keeps staggered slices unpublished until the batch completes', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = await createStore({
+        schema: [{ name: 'TestCollection' }],
+        plugins: [],
+        cacheStaggering: 2,
+      })
+      const cache = store.$cache
+      const collection = store.$collections[0]!
+      const observedLengths: number[] = []
+      const stop = watchSyncEffect(() => {
+        observedLengths.push(cache.readItems({ collection }).length)
+      })
+
+      try {
+        cache.writeItems({
+          collection,
+          marker: 'testMarker',
+          items: Array.from({ length: 5 }, (_, index) => ({
+            key: index + 1,
+            value: { id: index + 1, name: `Item ${index + 1}` },
+          })),
+        })
+
+        expect(cache.readItem({ collection, key: 1 })).toEqual({ id: 1, name: 'Item 1' })
+        expect(cache.readItem({ collection, key: 2 })).toEqual({ id: 2, name: 'Item 2' })
+        expect(cache.readItem({ collection, key: 3 })).toBeUndefined()
+        expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(0)
+        expect(observedLengths).toEqual([0])
+
+        vi.advanceTimersByTime(10)
+
+        expect(cache.readItem({ collection, key: 3 })).toEqual({ id: 3, name: 'Item 3' })
+        expect(cache.readItem({ collection, key: 4 })).toEqual({ id: 4, name: 'Item 4' })
+        expect(cache.readItem({ collection, key: 5 })).toBeUndefined()
+        expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(0)
+        expect(observedLengths).toEqual([0])
+
+        vi.advanceTimersByTime(10)
+
+        expect(cache.readItem({ collection, key: 5 })).toEqual({ id: 5, name: 'Item 5' })
+        expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(5)
+        expect(observedLengths).toEqual([0, 5])
+      }
+      finally {
+        stop()
+      }
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('settles a staggered nested failure before corrected retry and later work progress', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = await createStore({
+        schema: [
+          {
+            name: 'Parent',
+            relations: {
+              related: { to: { Related: { on: { id: 'relatedId' } } }, many: false },
+              other: { to: { Other: { on: { id: 'otherId' } } }, many: false },
+            },
+          },
+          { name: 'Related' },
+          { name: 'Other' },
+          { name: 'Independent' },
+        ],
+        plugins: [],
+        cacheStaggering: 1,
+      })
+      const cache = store.$cache
+      const parentCollection = store.$collections[0]!
+      const relatedCollection = store.$collections[1]!
+      const otherCollection = store.$collections[2]!
+      const independentCollection = store.$collections[3]!
+      const items: Array<{ key: number, value: any }> = [
+        { key: 1, value: { id: 1, name: 'First' } },
+        {
+          key: 2,
+          value: {
+            id: 2,
+            relatedId: 11,
+            related: { id: 11, name: 'Related' },
+            otherId: 21,
+            other: [{ id: 21, name: 'Invalid to-one value' }],
+          },
+        },
+      ]
+      const parentLengths: number[] = []
+      const relatedLengths: number[] = []
+      const otherLengths: number[] = []
+      const hookSnapshots: string[] = []
+      const stopParent = watchSyncEffect(() => {
+        parentLengths.push(cache.readItems({ collection: parentCollection }).length)
+      })
+      const stopRelated = watchSyncEffect(() => {
+        relatedLengths.push(cache.readItems({ collection: relatedCollection }).length)
+      })
+      const stopOther = watchSyncEffect(() => {
+        otherLengths.push(cache.readItems({ collection: otherCollection }).length)
+      })
+      store.$hooks.hook('afterCacheWrite', ({ collection, result }) => {
+        if (collection.name === relatedCollection.name || collection.name === otherCollection.name) {
+          hookSnapshots.push(`${collection.name}:${parentLengths.at(-1)}:${relatedLengths.at(-1)}:${otherLengths.at(-1)}`)
+        }
+        else if (collection.name === parentCollection.name && Array.isArray(result) && result.length === items.length) {
+          hookSnapshots.push(`outer:${parentLengths.at(-1)}:${relatedLengths.at(-1)}:${otherLengths.at(-1)}`)
+        }
+      })
+
+      try {
+        cache.writeItems({ collection: parentCollection, items })
+
+        expect(parentLengths).toEqual([0])
+        expect(relatedLengths).toEqual([0])
+        expect(otherLengths).toEqual([0])
+
+        expect(() => vi.advanceTimersByTime(10)).toThrow('Expected object for relation Parent.other')
+
+        expect(parentLengths).toEqual([0, 1])
+        expect(relatedLengths).toEqual([0, 1])
+        expect(otherLengths).toEqual([0])
+        expect(hookSnapshots).toEqual(['Related:1:1:0'])
+
+        items[1]!.value.other = { id: 21, name: 'Valid on retry' }
+        cache.writeItem({
+          collection: independentCollection,
+          key: 1,
+          item: { id: 1, name: 'Later queued write' },
+        })
+
+        expect(parentLengths).toEqual([0, 1, 2])
+        expect(relatedLengths).toEqual([0, 1, 1])
+        expect(otherLengths).toEqual([0, 1])
+        expect(hookSnapshots).toEqual([
+          'Related:1:1:0',
+          'Related:2:1:1',
+          'Other:2:1:1',
+          'outer:2:1:1',
+        ])
+        expect(cache.readItem({ collection: independentCollection, key: 1 })).toBeUndefined()
+
+        vi.advanceTimersByTime(10)
+
+        expect(cache.readItem({ collection: independentCollection, key: 1 })).toEqual({ id: 1, name: 'Later queued write' })
+      }
+      finally {
+        stopParent()
+        stopRelated()
+        stopOther()
+      }
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/vue/test/integration/cache/publication-staggering.spec.ts
+++ b/packages/vue/test/integration/cache/publication-staggering.spec.ts
@@ -58,6 +58,83 @@ describe('cache writeItems', () => {
     }
   })
 
+  it('settles an already-written stale slice without marking or emitting the outer batch hook', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = await createStore({
+        schema: [
+          {
+            name: 'Parent',
+            relations: {
+              child: { to: { Child: { on: { id: 'childId' } } }, many: false },
+            },
+          },
+          { name: 'Child' },
+        ],
+        plugins: [],
+        cacheStaggering: 1,
+      })
+      const cache = store.$cache
+      const parentCollection = store.$collections[0]!
+      const childCollection = store.$collections[1]!
+      const parentLengths: number[] = []
+      const childLengths: number[] = []
+      const hookEvents: string[] = []
+      let canPublish = true
+      const stopParent = watchSyncEffect(() => {
+        parentLengths.push(cache.readItems({ collection: parentCollection }).length)
+      })
+      const stopChild = watchSyncEffect(() => {
+        childLengths.push(cache.readItems({ collection: childCollection }).length)
+      })
+      store.$hooks.hook('afterCacheWrite', ({ collection, key, result }) => {
+        if (collection.name === childCollection.name) {
+          hookEvents.push(`${collection.name}:${key}`)
+        }
+        else if (collection.name === parentCollection.name && Array.isArray(result)) {
+          hookEvents.push('outer')
+        }
+      })
+
+      try {
+        cache.writeItems({
+          collection: parentCollection,
+          marker: 'stale-marker',
+          meta: { $canPublishQuery: () => canPublish },
+          items: [
+            {
+              key: 1,
+              value: {
+                id: 1,
+                childId: 11,
+                child: { id: 11, name: 'Already written child' },
+              },
+            },
+            { key: 2, value: { id: 2 } },
+          ],
+        })
+
+        canPublish = false
+        vi.advanceTimersByTime(10)
+
+        expect(parentLengths).toEqual([0, 1])
+        expect(childLengths).toEqual([0, 1])
+        expect(cache.readItems({ collection: parentCollection }).map(item => item.id)).toEqual([1])
+        expect(cache.readItems({ collection: childCollection }).map(item => item.id)).toEqual([11])
+        expect(cache.readItems({ collection: parentCollection, marker: 'stale-marker' })).toEqual([])
+        expect(hookEvents).toEqual(['Child:11'])
+      }
+      finally {
+        stopParent()
+        stopChild()
+      }
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('settles a staggered nested failure before corrected retry and later work progress', async () => {
     vi.useFakeTimers()
 

--- a/packages/vue/test/integration/cache/publication.spec.ts
+++ b/packages/vue/test/integration/cache/publication.spec.ts
@@ -1,0 +1,264 @@
+import { createTestStore as createStore } from '#test-utils/store/integrationStore'
+import { describe, expect, it } from 'vitest'
+import { watchSyncEffect } from 'vue'
+
+describe('cache writeItems', () => {
+  it('publishes 1000 items once to a warmed reactive collection reader', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    const items = Array.from({ length: 1000 }, (_, index) => ({
+      key: index + 1,
+      value: { id: index + 1, name: `Item ${index + 1}` },
+    }))
+
+    // Prime the overlay cache before subscribing. Cached readers still need to
+    // subscribe to the collection publication used by batched writes.
+    expect(cache.readItems({ collection })).toEqual([])
+
+    const observedLengths: number[] = []
+    const stop = watchSyncEffect(() => {
+      observedLengths.push(cache.readItems({ collection }).length)
+    })
+
+    try {
+      cache.writeItems({ collection, items })
+
+      expect(observedLengths).toEqual([0, 1000])
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('keeps individual writeItem publication immediate', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    let observedLength = -1
+    const stop = watchSyncEffect(() => {
+      observedLength = cache.readItems({ collection }).length
+    })
+
+    try {
+      cache.writeItem({ collection, key: 1, item: { id: 1 } })
+      expect(observedLength).toBe(1)
+
+      cache.writeItem({ collection, key: 2, item: { id: 2 } })
+      expect(observedLength).toBe(2)
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('marks before publication and runs the outer hook after publication', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    const events: string[] = []
+    const stop = watchSyncEffect(() => {
+      const allItems = cache.readItems({ collection })
+      const markedItems = cache.readItems({ collection, marker: 'test-marker' })
+      events.push(`reactive:${allItems.length}:${markedItems.length}`)
+    })
+    store.$hooks.hook('afterCacheWrite', ({ marker, result }) => {
+      const markedItems = cache.readItems({ collection, marker: 'test-marker' })
+      events.push(`hook:${marker}:${Array.isArray(result) ? result.length : 1}:${markedItems.length}`)
+    })
+
+    try {
+      cache.writeItems({
+        collection,
+        marker: 'test-marker',
+        items: [
+          { key: 1, value: { id: 1 } },
+          { key: 2, value: { id: 2 } },
+        ],
+      })
+
+      expect(events).toEqual([
+        'reactive:0:0',
+        'reactive:2:2',
+        'hook:test-marker:2:2',
+      ])
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('publishes once to an existing wrapped item', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    cache.writeItem({ collection, key: 1, item: { id: 1, name: 'Before' } })
+    const wrappedItem = cache.readItem({ collection, key: 1 })!
+    const observedNames: string[] = []
+    const stop = watchSyncEffect(() => {
+      observedNames.push(wrappedItem.name)
+    })
+
+    try {
+      cache.writeItems({
+        collection,
+        items: [
+          { key: 1, value: { id: 1, name: 'Intermediate' } },
+          { key: 1, value: { id: 1, name: 'After' } },
+        ],
+      })
+
+      expect(observedNames).toEqual(['Before', 'After'])
+      expect(cache.readItem({ collection, key: 1 })).toBe(wrappedItem)
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('publishes once when collection layers are active', async () => {
+    const store = await createStore({
+      schema: [{ name: 'TestCollection' }],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    cache.writeItem({ collection, key: 1, item: { id: 1, name: 'Base' } })
+    cache.addLayer({
+      id: 'test-layer',
+      collectionName: collection.name,
+      state: { 1: { name: 'Layered' } },
+      deletedItems: new Set(),
+    })
+    expect(cache.readItems({ collection }).map(item => item.name)).toEqual(['Layered'])
+
+    const observedNames: string[][] = []
+    const stop = watchSyncEffect(() => {
+      observedNames.push(cache.readItems({ collection }).map(item => item.name))
+    })
+
+    try {
+      cache.writeItems({
+        collection,
+        items: [
+          { key: 1, value: { id: 1, name: 'Updated base' } },
+          { key: 2, value: { id: 2, name: 'Second item' } },
+        ],
+      })
+
+      expect(observedNames).toEqual([
+        ['Layered'],
+        ['Layered', 'Second item'],
+      ])
+    }
+    finally {
+      stop()
+    }
+  })
+
+  it('publishes nested collections before draining child hooks and the outer hook', async () => {
+    const store = await createStore({
+      schema: [
+        {
+          name: 'TestCollection',
+          relations: {
+            related: { to: { RelatedCollection: { on: { id: 'relatedId' } } }, many: false },
+          },
+        },
+        { name: 'RelatedCollection' },
+      ],
+      plugins: [],
+    })
+    const cache = store.$cache
+    const collection = store.$collections[0]!
+    const relatedCollection = store.$collections[1]!
+    const observedParentLengths: number[] = []
+    const observedRelatedLengths: number[] = []
+    const observedRelationNames: string[][] = []
+    const events: string[] = []
+    const stopParents = watchSyncEffect(() => {
+      const length = cache.readItems({ collection }).length
+      observedParentLengths.push(length)
+      events.push(`parent-reactive:${length}`)
+    })
+    const stopRelated = watchSyncEffect(() => {
+      const length = cache.readItems({ collection: relatedCollection }).length
+      observedRelatedLengths.push(length)
+      events.push(`related-reactive:${length}`)
+    })
+    const stopRelations = watchSyncEffect(() => {
+      observedRelationNames.push(cache.readItems({ collection }).map(item => (item as any).related?.name))
+    })
+    store.$hooks.hook('afterCacheWrite', ({ collection: hookCollection, key, result }) => {
+      if (hookCollection.name === relatedCollection.name) {
+        events.push(`child:${key}:${observedParentLengths.at(-1)}:${observedRelatedLengths.at(-1)}`)
+      }
+      else if (hookCollection.name === collection.name && Array.isArray(result) && result.length === 2) {
+        events.push(`outer:${observedParentLengths.at(-1)}:${observedRelatedLengths.at(-1)}`)
+      }
+    })
+
+    try {
+      cache.writeItems({
+        collection,
+        items: [
+          {
+            key: 1,
+            value: {
+              id: 1,
+              relatedId: 11,
+              related: { id: 11, name: 'Related 1' },
+            },
+          },
+          {
+            key: 2,
+            value: {
+              id: 2,
+              relatedId: 12,
+              related: { id: 12, name: 'Related 2' },
+            },
+          },
+        ],
+      })
+
+      expect(observedParentLengths).toEqual([0, 2])
+      expect(observedRelatedLengths).toEqual([0, 2])
+      expect(events).toEqual([
+        'parent-reactive:0',
+        'related-reactive:0',
+        'parent-reactive:2',
+        'related-reactive:2',
+        'child:11:2:2',
+        'child:12:2:2',
+        'outer:2:2',
+      ])
+      expect(observedRelationNames[0]).toEqual([])
+      expect(observedRelationNames.length).toBeGreaterThan(1)
+      for (const relationNames of observedRelationNames.slice(1)) {
+        expect(relationNames).toEqual(['Related 1', 'Related 2'])
+      }
+      expect(cache.readItems({
+        collection: relatedCollection,
+        indexKey: 'id',
+        indexValue: '11',
+      }).map(item => item.name)).toEqual(['Related 1'])
+    }
+    finally {
+      stopParents()
+      stopRelated()
+      stopRelations()
+    }
+  })
+})

--- a/packages/vue/test/integration/cache/write-pacing.spec.ts
+++ b/packages/vue/test/integration/cache/write-pacing.spec.ts
@@ -2,49 +2,6 @@ import { createTestStore as createStore } from '#test-utils/store/integrationSto
 import { describe, expect, it, vi } from 'vitest'
 
 describe('cache', () => {
-  it('should stagger batched cache writes when cacheStaggering is enabled', async () => {
-    vi.useFakeTimers()
-
-    try {
-      const store = await createStore({
-        schema: [{ name: 'TestCollection' }],
-        plugins: [],
-        cacheStaggering: 2,
-      })
-      const cache = store.$cache
-      const collection = store.$collections[0]!
-
-      cache.writeItems({
-        collection,
-        marker: 'testMarker',
-        items: Array.from({ length: 5 }, (_, index) => ({
-          key: index + 1,
-          value: { id: index + 1, name: `Item ${index + 1}` },
-        })),
-      })
-
-      expect(cache.readItem({ collection, key: 1 })).toEqual({ id: 1, name: 'Item 1' })
-      expect(cache.readItem({ collection, key: 2 })).toEqual({ id: 2, name: 'Item 2' })
-      expect(cache.readItem({ collection, key: 3 })).toBeUndefined()
-      expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(0)
-
-      vi.advanceTimersByTime(10)
-
-      expect(cache.readItem({ collection, key: 3 })).toEqual({ id: 3, name: 'Item 3' })
-      expect(cache.readItem({ collection, key: 4 })).toEqual({ id: 4, name: 'Item 4' })
-      expect(cache.readItem({ collection, key: 5 })).toBeUndefined()
-      expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(0)
-
-      vi.advanceTimersByTime(10)
-
-      expect(cache.readItem({ collection, key: 5 })).toEqual({ id: 5, name: 'Item 5' })
-      expect(cache.readItems({ collection, marker: 'testMarker' })).toHaveLength(5)
-    }
-    finally {
-      vi.useRealTimers()
-    }
-  })
-
   it('should stagger sequential writeItem calls in the same 10ms window', async () => {
     vi.useFakeTimers()
 

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -21,6 +21,7 @@
   },
   "include": [
     "src",
-    "test"
+    "test",
+    "benchmark"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ catalogs:
     unbuild:
       specifier: ^3.2.0
       version: 3.6.1
+    vite-node:
+      specifier: 6.0.0
+      version: 6.0.0
     vitepress:
       specifier: ^2.0.0-alpha.16
       version: 2.0.0-alpha.20
@@ -1029,6 +1032,9 @@ importers:
       unbuild:
         specifier: 'catalog:'
         version: 3.6.1(typescript@5.9.3)(vue-tsc@3.3.11(typescript@5.9.3))(vue@3.5.42(typescript@5.9.3))
+      vite-node:
+        specifier: 'catalog:'
+        version: 6.0.0(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 5.0.0(@types/node@26.5.0)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ catalog:
   three: ^0.183.2
   typescript: ^5.9.2
   unbuild: ^3.2.0
+  vite-node: 6.0.0
   vitepress: ^2.0.0-alpha.16
   vitest: ^5.0.0
   vue: 3.5.42


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Bulk cache writes now publish one reactive update per affected collection instead of notifying Vue dependents after every item. This removes repeated synchronous query recomputation while preserving immediate `writeItem` behavior, nested relation consistency, hook ordering, and retryable partial failures.

The PR now includes an RStore-native benchmark that exercises the real Vue cache runtime, public `peekMany` query API, a Vue computed, and a synchronous watcher:

```sh
pnpm --filter @rstore/vue benchmark:write-items
```

The optimized case calls the public `cache.writeItems` API. The control reproduces the parent commit's flat, active, non-staggered `writeItems` path with the real `writeItemNow`, including per-item reactive publication and one outer hook. Each mode gets two warmups and 20 measured samples in alternating order, with a new store and cache for every sample.

For 1,000 items, a clean-process run on Node v26.5.0 and an Apple M4 Pro produced:

| Metric | Legacy per-item control | Atomic `writeItems` |
| --- | ---: | ---: |
| Median | 758.051 ms | 1.624 ms |
| p95 | 864.371 ms | 2.389 ms |
| MAD | 32.439 ms | 0.073 ms |
| Visible query transitions | 1,000 | 1 |
| Watcher notifications | 3,000 | 1 |
| Query recomputations | 3,001 | 2 |
| Outer hooks | 1 | 1 |

Both paths produced the same final cache and query digest. This run measured a 466.864× median speedup. Timing is descriptive and machine-dependent; the benchmark fails only when the final semantics, hook payload, or publication/recomputation counts differ.

<details>
<summary>Recorded 1,000-item timing samples and source provenance</summary>

- Source commit: `e6633e291f0a1212f75d6d839b52b622e7cd4a90`
- Clean worktree: `true`
- Benchmark source SHA-256: `41ebc39a12e7d48d526eff79b758e22ff884baf67fb8f905a8195bffafa4de10`
- Legacy raw milliseconds: `[712.311, 707.645, 708.969, 752.247, 709.683, 846.453, 772.726, 732.693, 720.207, 733.25, 731.016, 770.027, 762.509, 781.253, 871.926, 838.172, 798.52, 753.594, 764.693, 864.371]`
- Atomic raw milliseconds: `[1.557, 1.419, 1.508, 1.491, 1.582, 1.478, 1.628, 1.68, 1.843, 1.543, 1.74, 2.536, 1.619, 1.561, 1.673, 2.208, 2.389, 1.597, 1.642, 1.631]`

</details>

The exact control is limited to the benchmarked flat, non-staggered case. It does not claim to reproduce legacy staggering, nested-relation settlement, or error handling; focused tests cover those production contracts.

This is an atomic reactive-publication boundary, not a rollback transaction. Imperative cache reads can still observe already-written raw state during a staggered batch. If a later item fails, successful earlier writes are published before the error is returned, and the failed item remains retryable.

The settlement boundary also guarantees that:

- all affected parent, child, index, and layered collection readers publish before nested `afterCacheWrite` hooks run;
- nested hooks keep insertion order and run before the successful outer batch hook;
- the original item-write error remains the primary error when publication also fails;
- a subscriber or hook error after completion cannot strand work already queued behind the batch.

### Additional context

The public `writeItems` API and multi-result `applyMutation` path share one batch initializer. `CacheWriteBatch` owns the affected collection set and deferred nested-hook payloads, so batching policy stays in the cache repository instead of leaking into consumers.

Mutation testing removed batch propagation and produced 11 focused failures while immediate single-item publication stayed green. The final checks are:

- `pnpm --filter @rstore/vue benchmark:write-items` — semantic and structural assertions passed
- `pnpm vitest run packages/vue/test` — 17 files, 261 tests passed
- `pnpm --filter @rstore/vue test:types` — passed, including the benchmark source
- scoped ESLint over all changed Vue cache and benchmark files — passed
- `pnpm --filter @rstore/vue build` — passed
- `pnpm install --lockfile-only --offline --frozen-lockfile` — passed
- `git diff --check` — passed

The local monorepo-wide build and test commands could not complete because this checkout is missing generated Nuxt configs and package-local binaries such as `nuxt-module-build`. The affected package checks above pass; CI should run the full matrix in a prepared checkout.

Reviewer focus: queue completion after subscriber/hook exceptions, partial-failure retry semantics, the benchmark control's explicit scope, and the distinction between reactive atomicity and rollback.

## New concepts

### Atomic reactive publication

The cache still performs each raw item mutation in order, but it delays Vue notifications until the batch settles. One batch object records which collections changed and which nested hooks must run later.

This is preferable to disabling each consumer watcher because the cache owns the publication contract. It also covers public writes, mutation results, relations, indexes, and layers through one seam.

Do not use this pattern when intermediate states are part of the public contract. It is also not a substitute for transactional rollback because successful raw writes remain applied after a later failure.

## Post-Deploy Monitoring & Validation

- Healthy signal: bulk consumer ingestion no longer creates a multi-second synchronous task, and collection readers observe one final publication per batch.
- Failure signals: stale relation/index reads, missing or duplicate `afterCacheWrite` hooks, or queued writes that stop progressing after a subscriber error.
- Validation window: the first package preview/release and its first Directus Studio consumer run.
- Owner: PR author with RStore maintainers.
- Rollback: revert this PR or pin consumers to the previous `@rstore/vue` release.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] If it's a new feature, provide a convincing reason to add it. *Ideally, you should open a suggestion issue first and have it approved before working on it.*
- [x] Read the [Contributing Guidelines](https://github.com/Akryum/rstore/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/Akryum/rstore/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/Akryum/rstore/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
